### PR TITLE
Add Gumroad Promo Banner Component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@ import { SpeedInsights } from '@vercel/speed-insights/vue';
 
 import TheHeader from '@/components/layout/TheHeader.vue';
 import TheFooter from '@/components/layout/TheFooter.vue';
+import GumroadPromo from './components/GumroadPromo.vue';
 
 useHead({
   title: 'Ara Hovsepyan | Vue.js Front-End Developer',
@@ -71,6 +72,8 @@ router.afterEach((to, from) => {
       </main>
     </Transition>
   </router-view>
+
+  <GumroadPromo />
 
   <TheFooter v-if="!isAdminRoute" />
 </template>

--- a/src/assets/button.scss
+++ b/src/assets/button.scss
@@ -70,6 +70,10 @@ button {
     }
   }
 
+  &-tertiary {
+    color: var(--vt-c-white);
+  }
+
   &-icon {
     span {
       display: flex;

--- a/src/assets/transition.scss
+++ b/src/assets/transition.scss
@@ -10,6 +10,8 @@
 
 .slide-up-enter-active,
 .slide-up-leave-active,
+.slide-up-fade-enter-active,
+.slide-up-fade-leave-active,
 .slide-down-enter-active,
 .slide-down-leave-active,
 .slide-left-enter-active,
@@ -29,6 +31,18 @@
 }
 .slide-up-enter-to {
   transform: translateY(0);
+  opacity: 1;
+}
+
+.slide-up-fade-enter-from {
+  transform: translateY(50%);
+  opacity: 0;
+}
+.slide-up-fade-leave-to {
+  transform: translateY(50%);
+  opacity: 0;
+}
+.slide-up-fade-enter-to {
   opacity: 1;
 }
 

--- a/src/components/GumroadPromo.vue
+++ b/src/components/GumroadPromo.vue
@@ -1,0 +1,105 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import BaseLink from './UI/BaseLink.vue';
+import BaseButton from './UI/BaseButton.vue';
+
+const showPromo = ref(false);
+
+onMounted(() => {
+  const hasSeenPromo = sessionStorage.getItem('gumroad-promo-seen');
+  if (!hasSeenPromo) {
+    setTimeout(() => {
+      showPromo.value = true;
+      sessionStorage.setItem('gumroad-promo-seen', 'true');
+    }, 5000);
+  }
+});
+
+const closePromo = () => {
+  showPromo.value = false;
+};
+</script>
+
+<template>
+  <transition name="slide-up-fade">
+    <div v-if="showPromo" class="gumroad-promo">
+      <div class="gumroad-promo__content">
+        <div class="gumroad-promo__text">
+          <h3>New on Gumroad</h3>
+          <p>Check out my latest Vue Composables Kit and other developer tools on Gumroad!</p>
+          <BaseLink
+            @click="closePromo"
+            class="gumroad-promo__link"
+            href="https://arahovsepyan.gumroad.com"
+            target="_blank"
+            rel="noopener"
+          >
+            Visit Store →
+          </BaseLink>
+        </div>
+
+        <BaseButton @click="closePromo" class="gumroad-promo__close" btn_class="btn-tertiary">
+          ✕
+        </BaseButton>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<style lang="scss" scoped>
+.gumroad-promo {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: var(--vt-c-purple-800);
+  padding: 1rem;
+  z-index: 1000;
+
+  @media (min-width: 1024px) {
+    padding: 2rem;
+  }
+
+  &__content {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  &__text {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    gap: 0.25rem;
+
+    h3 {
+      color: var(--vt-c-white);
+      font-size: 1.25rem;
+      font-weight: 600;
+
+      @media (min-width: 1024px) {
+        font-size: 1.75rem;
+      }
+    }
+
+    p {
+      color: var(--vt-c-gray-300);
+      margin-bottom: 0.5rem;
+      font-size: 1rem;
+
+      @media (min-width: 1024px) {
+        font-size: 1.25rem;
+      }
+    }
+  }
+  &__link {
+    border-radius: 0;
+    min-width: 200px;
+
+    @media (max-width: 1024px) {
+      min-width: 160px;
+      height: 40px;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
This merge request introduces a new GumroadPromo.vue component that:
	•	Slides up from the bottom of the screen on page load (with a short delay)
	•	Encourages visitors to check out the Gumroad profile and products
	•	Includes a dismiss button and stores dismissal state in localStorage to avoid repeated prompts
	•	Follows mobile-first SCSS styling, fully responsive

This feature aims to increase visibility and traffic to the Gumroad page without being intrusive.